### PR TITLE
Use Supplier interface to implement lazy loading of FieldApplications.

### DIFF
--- a/src/main/java/com/vzome/core/editor/Application.java
+++ b/src/main/java/com/vzome/core/editor/Application.java
@@ -138,37 +138,13 @@ public class Application
 
         // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         // add all of the parameterless FieldApplication suppliers
-        this.fieldAppSuppliers.put("golden", new Supplier<FieldApplication>() {
-            @Override
-            public FieldApplication get() {
-                return new GoldenFieldApplication();
-            }
-        });
-        this.fieldAppSuppliers.put("rootTwo", new Supplier<FieldApplication>() {
-            @Override
-            public FieldApplication get() {
-                return new RootTwoFieldApplication();
-            }
-        });
+        this.fieldAppSuppliers.put("golden", GoldenFieldApplication::new);
+        this.fieldAppSuppliers.put("rootTwo", RootTwoFieldApplication::new);
         this.fieldAppSuppliers.put("dodecagon",  // for legacy documents
-        this.fieldAppSuppliers.put("rootThree", new Supplier<FieldApplication>() {
-            @Override
-            public FieldApplication get() {
-                return new RootThreeFieldApplication();
-            }
-        }) );
-        this.fieldAppSuppliers.put("heptagon", new Supplier<FieldApplication>() {
-            @Override
-            public FieldApplication get() {
-                return new HeptagonFieldApplication();
-            }
-        });
-        this.fieldAppSuppliers.put("snubDodec", new Supplier<FieldApplication>() {
-            @Override
-            public FieldApplication get() {
-                return new SnubDodecFieldApplication();
-            }
-        });
+        this.fieldAppSuppliers.put("rootThree", RootThreeFieldApplication::new)
+        );
+        this.fieldAppSuppliers.put("heptagon", HeptagonFieldApplication::new);
+        this.fieldAppSuppliers.put("snubDodec", SnubDodecFieldApplication::new);
 
         // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         // Now add all of the parameterized FieldApplication functions


### PR DESCRIPTION
This is the general approach I intend to eventually use for discovering and generating the parameterized fields, so I implemented it for the existing fields first. This approach avoids the need to list the various kinds of field application in multiple places since we avoid the big switch in getDocumentKind and we are once again returning the keySet() in getFieldNames() as well.